### PR TITLE
Respect specified configs when setting headers

### DIFF
--- a/lib/throttler.js
+++ b/lib/throttler.js
@@ -45,25 +45,25 @@ module.exports = function createThrottler (config, limited) {
   }
 
   function respondWithThrottle (request, response, next, throttle) {
-    var timeUntilReset = (defaults.rateLimit.ttl * 1000) - (new Date().getTime() - throttle.createdAt.getTime())
-    var remaining = Math.max(0, (defaults.rateLimit.max - throttle.hits))
+    var timeUntilReset = (config.rateLimit.ttl * 1000) - (new Date().getTime() - throttle.createdAt.getTime())
+    var remaining = Math.max(0, (config.rateLimit.max - throttle.hits))
 
     response.set({
-      'X-Rate-Limit-Limit': defaults.rateLimit.max,
+      'X-Rate-Limit-Limit': config.rateLimit.max,
       'X-Rate-Limit-Remaining': remaining,
       'X-Rate-Limit-Reset': timeUntilReset
     })
 
-    if (throttle.hits < defaults.rateLimit.max) {
+    if (throttle.hits < config.rateLimit.max) {
       return next()
     }
 
-    response.statusCode = defaults.response.code
+    response.statusCode = config.response.code
     if (limited) {
       return limited(request, response, throttle.hits, timeUntilReset)
     }
 
-    return response.send(defaults.response.message)
+    return response.send(config.response.message)
   }
   /**
    * Check for request limit on the requesting IP


### PR DESCRIPTION
## Description

Once the defaults have been used to back-fill on the `config` object, we should just use that.
## Motivation and Context

Some people like different configuration. :)
## How Has This Been Tested?

Tests pass.
## Types of changes
- Bug fix (non-breaking change which fixes an issue)

Solves #3
