### PR TITLE
Added `useCustomHeader` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ X-Rate-Limit-Reset      # msec until limit reset for IP
         "message": "Rate Limit reached. Please wait and try again."
     },
     "mongoose":{
-	"uri": false    // Optional Mongo URI connection string
-    }
+        "uri": false    // Optional Mongo URI connection string
+    },
+    "useCustomHeader": "x-custom-header" // Count hits by the distinct values found in this header, instead of by IP
 }
 
 // When using a custom limit handler:

--- a/example/app_with_config.js
+++ b/example/app_with_config.js
@@ -3,8 +3,14 @@ var app = express()
 var mongoose = require('mongoose')
 mongoose.connect('mongodb://localhost/mongothrottle')
 
+var throttlerOptions = {
+  rateLimit: {max: 10},
+  mongoose: {uri: 'mongodb://localhost/mongothrottle'},
+  useCustomHeader: 'x-custom-header'
+}
+
 var throttler = require('../lib/throttler')
-app.use(throttler({rateLimit: {max: 10}, mongoose: {uri: 'mongodb://localhost/mongothrottle'}}))
+app.use(throttler(throttlerOptions))
 
 // REMOVE PRIOR DOCUMENTS
 var Throttle = mongoose.model('Throttle')

--- a/lib/throttler.js
+++ b/lib/throttler.js
@@ -73,16 +73,22 @@ module.exports = function createThrottler (config, limited) {
    */
 
   function throttleMiddleware (request, response, next) {
-    var ip = request.headers['x-forwarded-for'] ||
-      request.connection.remoteAddress ||
-      request.socket.remoteAddress ||
-      request.connection.socket.remoteAddress || ''
+    var ip = null
 
-    ip = ip.split(',')[0]
-    if (!ipRegex().test(ip) || ip.substr(0, 7) === '::ffff:' || ip === '::1') {
-      ip = '127.0.0.1'
+    if (config.useCustomHeader && request.headers[config.useCustomHeader]) {
+      ip = request.headers[config.useCustomHeader]
     } else {
-      ip = ip.match(ipRegex())[0]
+      ip = request.headers['x-forwarded-for'] ||
+        request.connection.remoteAddress ||
+        request.socket.remoteAddress ||
+        request.connection.socket.remoteAddress || ''
+
+      ip = ip.split(',')[0]
+      if (!ipRegex().test(ip) || ip.substr(0, 7) === '::ffff:' || ip === '::1') {
+        ip = '127.0.0.1'
+      } else {
+        ip = ip.match(ipRegex())[0]
+      }
     }
 
     Throttle


### PR DESCRIPTION
## Description
Added a configuration option to `useCustomHeader`.
This will allow module users to throttle not only based on IP, but also using other headers.

## Motivation and Context
We came across a requirement in my workplace that needed rate-limiting with a mongo backend, but not based on IP, but by a specific header we get in the requests.

## How Has This Been Tested?
Added a test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
